### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/tldr-sharp/Cache.cs
+++ b/tldr-sharp/Cache.cs
@@ -14,7 +14,7 @@ namespace tldr_sharp
 {
     internal static class Cache
     {
-        private const string Remote = "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages";
+        private const string Remote = "https://raw.githubusercontent.com/tldr-pages/tldr/main/pages";
 
         internal static void Check()
         {

--- a/tldr-sharp/PageController.cs
+++ b/tldr-sharp/PageController.cs
@@ -118,7 +118,7 @@ namespace tldr_sharp
                 if (prefLanguage != null) {
                     Console.WriteLine(
                         $"The `{pageName}` page could not be found in {Locale.GetLanguageName(prefLanguage)}. " +
-                        $"{Environment.NewLine}Feel free to translate it: https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md#translations");
+                        $"{Environment.NewLine}Feel free to translate it: https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md#translations");
                     return 2;
                 }
 

--- a/tldr-sharp/Updater.cs
+++ b/tldr-sharp/Updater.cs
@@ -18,7 +18,7 @@ namespace tldr_sharp
         private const string Remote = "https://tldr.sh/assets/tldr.zip";
 
         private const string AlternativeRemote =
-            "https://github.com/tldr-pages/tldr-pages.github.io/raw/master/assets/tldr.zip";
+            "https://github.com/tldr-pages/tldr-pages.github.io/raw/main/assets/tldr.zip";
 
         internal static void Update()
         {


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).